### PR TITLE
Fixed numpy error on macos

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
@@ -6,7 +8,7 @@ from Cython.Build import cythonize
 extensions = [
     Extension('dehaze', ['dehaze.pyx'],
               extra_compile_args=['-O3'],
-              include_dirs = [],
+              include_dirs = [np.get_include()],
               libraries = [],
               library_dirs = []),
 ]


### PR DESCRIPTION
I had the following issue on macos and fixed it.

````
$ python3 setup.py build_ext --inplace
Compiling dehaze.pyx because it changed.
[1/1] Cythonizing dehaze.pyx
running build_ext
building 'dehaze' extension
creating build
creating build/temp.macosx-10.12-x86_64-3.6
clang -Wno-unused-result -Wsign-compare -Wunreachable-code -fno-common -dynamic -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk -I/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/Tk.framework/Versions/8.5/Headers -I/usr/local/include -I/usr/local/opt/openssl/include -I/usr/local/opt/sqlite/include -I/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/include/python3.6m -c dehaze.c -o build/temp.macosx-10.12-x86_64-3.6/dehaze.o -O3
dehaze.c:447:10: fatal error: 'numpy/arrayobject.h' file not found
#include "numpy/arrayobject.h"
         ^
1 error generated.
error: command 'clang' failed with exit status 1
````